### PR TITLE
Muutettu viittausta tikape -> wepa

### DIFF
--- a/source/osa0.html.erb
+++ b/source/osa0.html.erb
@@ -459,7 +459,7 @@
 <% partial 'partials/hint', locals: { name: 'Jinja 2' } do %>
 
   <p>
-    Flask käyttää oletuksena <a href="http://jinja.pocoo.org/docs/2.10/">Jinja</a>-nimistä kirjastoa käyttäjälle näytettävien sivujen luomiseen. Jinja on hieman tietokantojen perusteista tutun Thymeleafin kaltainen kirjasto, jota käytetään HTML-sivujen luomiseen. Jinja mahdollistaa myös esimerkiksi toistolauseiden ym. käyttämisen osana HTML-näkymiä -- sivut luodaan palvelimella.
+    Flask käyttää oletuksena <a href="http://jinja.pocoo.org/docs/2.10/">Jinja</a>-nimistä kirjastoa käyttäjälle näytettävien sivujen luomiseen. Jinja on hieman web-palvelinohjelmointi kurssilta tutun Thymeleafin kaltainen kirjasto, jota käytetään HTML-sivujen luomiseen. Jinja mahdollistaa myös esimerkiksi toistolauseiden ym. käyttämisen osana HTML-näkymiä -- sivut luodaan palvelimella.
   </p>
   
 <% end %>


### PR DESCRIPTION
Muutettu viittausta tietokantojen perusteista web-palvelinohjelmointiin. Tämän vuoden tietokantojen perusteet kurssilla ei käyty läpi Thymeafleafia. Wepassa se on esitelty.